### PR TITLE
Added process to copy a one year old event to make a new event

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Although if you're an organizer, coach or attendee and you want to know how we w
 - [First reply for new organizer request](howto/emails/organize-request-reply.md)
 - [Ping for organizers that are late](howto/emails/late-ping.md)
 - [Thank you email for organizer](howto/emails/thank_you.md)
+- [Email for a one year old team making a new event](howto/emails/copy_year_old_event.md)
 
 #### Process
 

--- a/howto/copy-event.md
+++ b/howto/copy-event.md
@@ -23,3 +23,29 @@ Website is ready here: http://djangogirls.org/berlin
 Congrats on yet another event!  
 
 :tada:!
+
+## If you're copying a one year old event
+
+1. Copy the previous event
+2. [Add organizer](../howto/add-organizer.md) if necessary
+2. Check if the team is on slack
+3. Check if the event has a dedicated email account ([nameofthecity]@djangogirls.org) and add it to the [event](https://djangogirls.org/admin/core/event/) if it's missing.
+4. Use this [email template](../howto/emails/copy_year_old_event.md) and send it to the team <3
+
+### Check if the team is on Slack
+
+1. Go to [slack admin interface](https://djangogirls.slack.com/admin)
+2. Use the search function
+
+### Add someone to Slack
+
+If the team has changed or you can't find them:
+
+1. Go to [slack admin interface](https://djangogirls.slack.com/admin)
+2. Click on "Invite new members"
+3. Click on "Full members"
+3. Add as many people as you need and click on "Invite n person"
+
+### Email account
+
+Old events usually have an email account but sometimes not connected to their event in our database. Add it to the new event in the [admin interface](https://djangogirls.org/admin/core/event/).

--- a/howto/emails/copy_year_old_event.md
+++ b/howto/emails/copy_year_old_event.md
@@ -1,0 +1,35 @@
+# E-mail template: Email for a one year old team making a new event
+
+Hi there!
+
+Congratulations on running a new Django Girls event! You rock!
+
+New features were added to the website since your last event: you can now manage applications from potential attendees on your website! To learn more about this, check our [organizer manual](http://organize.djangogirls.org/) ;)
+
+1) Email
+
+Your e-mail is **[Add email]**
+Login here: http://mail.djangogirls.org/
+**[Add email]** (@djangogirls.com works too!)
+**[Add password]**
+You can also add this inbox to your email client:
+- IMAP: imap.gmail.com (SSL, port 993)
+- SMTP: smtp.gmail.com (SSL, port 465)
+
+Or you can forward incoming mail to your private email account by following these instructions: http://gappstips.com/gmail/automatically-forward-emails-to-multiple-recipients-in-gmail/
+
+2) Website
+
+Your website address is still http://djangogirls.org/**[nameofthecity]**
+
+Login here:
+http://djangogirls.org/admin/
+**[New accounts]** or "Same credentials as before ;)"
+
+Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here: http://djangogirls.org/admin/core/eventpage/ and edit your website changing “is live” option.
+
+Instructions on editing website: http://organize.djangogirls.org/website/
+
+Let me know if you need anything. It’s usually faster to post questions to our Google Group of Django Girls Organizers or Slack channel - there are more people that can help you! :)
+
+Hugs, rainbows and sunshines!

--- a/rainbows/emails.md
+++ b/rainbows/emails.md
@@ -90,6 +90,38 @@ Baptiste to Mikey:
 
 Since then, you see similar signatures in almost all Django Girls communication, including ones with sponsors! Feel free to be creative and a bit fun!
 
+## How to stock and use template email in Gmail
 
+You can activate a cool feature in Gmail lab to grab a email template in two clicks.
 
+1. Click on the gear
+2. Select "Settings"
+3. Open the "labs" tap
+4. Search for "Canned Responses"
+5. Activate it
+6. Save your settings
 
+### Save a template
+
+1. Click on the "Compose" button
+2. Copy-past an email template from our wiki
+3. Give your email a subject
+4. Click on "More option" in the bottom-right of the email windows
+5. Go in "Canned responses" and save it by clicking on "new canned response"
+
+### Use a template
+
+1. Click on the "Compose" button
+2. Click on "More option" in the bottom-right of the email windows
+3. Go in "Canned responses" and select the template you want in the "insert" section
+4. Don't forget to adapt it if necessary and send your email :postbox:
+
+## How to cancel an email you just sent in Gmail
+
+You forgot to add hello@djangogirls.org in CC or sent an email to the wrong person! Well, it's too late for this time, so how to be sure it won't happen again?
+
+1. Click on the gear
+2. Select "Settings"
+3. Scroll to the "Undo Send:" section
+4. Click on "Enable Undo Send" and set a timer
+5. When you send an email, you will now have a small pop-up with a link to cancel the email you just sent.


### PR DESCRIPTION
I realized that the process of copying an event that happened more than a year ago is a bit different from copying one that happened two month before ;)
I'm lacking accurate data on some topics: when the "application form" and "automatically add to slack" were added? It will be better to change "a one year old event" to "event before this month/year".
If somebody can do that, it would be great :heart: 
