### PR TITLE
Update current and former Committers

### DIFF
--- a/general/people.md
+++ b/general/people.md
@@ -91,12 +91,26 @@ You can reach them by writing to translations@djangogirls.org.
 Committers have commit access to [our repositories](https://github.com/DjangoGirls).
 
 Team members:
+- Tomasz Magulski
+- Raphael Das Gupta
+- Patryk Zawadzki
+- Ramon Saraiva
 
+##### Former members:
 - Helen Sherwood-Taylor
 - Harry Percival
 - Honza Král
 - Paul Hallett
 - Marysia Lowas
+- Baptiste Mispelon
+- Ania Warzecha
+- Ola Sitarska
+- Ola Sendecka
+- Robert Kirberich
+- Michael Strutt
+- Anna Konopka
+- Krzysztof Żuraw
+
 
 ## Tutorial PR reviewers
 


### PR DESCRIPTION
We have just removed inactive committers from the Committers team on GitHub. This pull request reflects this change in our internal Wiki. Inactive committers are now former members of the Committers team. We have also updated the team of Current Members for Committers.